### PR TITLE
Use upstream IFrame widget for more consistent pointer events

### DIFF
--- a/packages/jyve/src/frame.ts
+++ b/packages/jyve/src/frame.ts
@@ -1,22 +1,22 @@
-import {Widget} from '@phosphor/widgets';
 import {Message} from '@phosphor/messaging';
+
+import {IFrame} from '@jupyterlab/apputils';
+
 import {Jyve} from '.';
 
 const FRAME_ICON_CLASS = 'jyv-FrameIcon';
 const FRAME_CLASS = 'jyv-Frame';
 
-export class JyvePanel extends Widget {
+export class JyvePanel extends IFrame {
   private _iframe: HTMLIFrameElement;
   private _kernel: Jyve.IJyveKernel;
 
-  constructor(options?: Widget.IOptions) {
-    super(options);
+  constructor() {
+    super();
     this.addClass(FRAME_CLASS);
     this.title.closable = true;
     this.title.icon = FRAME_ICON_CLASS;
-
-    this._iframe = document.createElement('iframe');
-    this.node.appendChild(this._iframe);
+    this._iframe = this.node.querySelector('iframe');
   }
 
   dispose() {
@@ -34,10 +34,7 @@ export class JyvePanel extends Widget {
   get kernel() { return this._kernel; }
   set kernel(kernel) {
     this._kernel = kernel;
-    kernel.frameCloseRequested.connect(() => {
-      console.log('disposing iframe');
-      this.dispose();
-    });
+    kernel.frameCloseRequested.connect(() => this.dispose());
     this._kernel.iframe(this._iframe);
   }
 }

--- a/packages/jyve/src/kernel.ts
+++ b/packages/jyve/src/kernel.ts
@@ -53,7 +53,6 @@ export class JyveKernel extends DefaultKernel implements Jyve.IJyveKernel {
 
   async iframe(iframe?: HTMLIFrameElement) {
     if (iframe !== void 0) {
-      console.log('setting frame', iframe);
       this._iframe = iframe;
       this._frameChanged.emit(this._iframe);
     } else {


### PR DESCRIPTION
As per @sccolbert's suggestion (thanks!) on #14, this uses `@jupyterlab/apputils:IFrame` to get more consistent IFrame handling. I was kinda hoping something would resolve towards a better security posture (which I would promptly ignore for this implementation) on https://github.com/jupyterlab/jupyterlab/issues/2369, but the usability is definitely far better this way.

Starting this now, but will also try to add a test to see if [robot/selenium](http://robotframework.org/Selenium2Library/Selenium2Library.html#Drag%20And%20Drop%20By%20Offset) is capable of catching this kind of thing

- [X] use IFrame widget
- [ ] add test?