### PR TITLE
fix theme path in exporter

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ channels:
 
 dependencies:
   - black
+  - beautysh
   - flake8
   - geckodriver
   - jupyterlab >=0.34,<0.35
@@ -18,5 +19,3 @@ dependencies:
   - robotframework-seleniumlibrary
   - selenium =3.8.0
   - wget
-  - pip:
-      - beautysh

--- a/jyve/exporter.py
+++ b/jyve/exporter.py
@@ -103,7 +103,7 @@ class JyveExporter(HTMLExporter):
             "staticDir": "~/jyve/static",
             "templatesDir": "~/jyve/templates",
             "themesDir": "~/jyve/themes/",
-            "themesUrl": "../lab/api/themes/",
+            "themesUrl": "/lab/api/themes/",
             "treeUrl": "../lab/tree/",
             "userSettingsDir": "~/jyve/lab/user-settings",
             "workspacesDir": "~/jyve/lab/workspaces",

--- a/tests/acceptance/Smoke.robot
+++ b/tests/acceptance/Smoke.robot
@@ -29,7 +29,7 @@ Jyve don't need no WebSocket
 *** Keywords ***
 Verify Kyrnels
     [Documentation]    Roughly check whether the Launcher contains all the kernels
-    Execute Jupyterlab Command   New Launcher 
+    Execute Jupyterlab Command    New Launcher
     Page Should Contain    Brython (unsafe)
     Page Should Contain    CoffeeScript (unsafe)
     Page Should Contain    JS (unsafe)


### PR DESCRIPTION
Under certain conditions (github pages) the URLs for theme content appear to be a it skewed. This has fixed it (experimentally), but pretty much need to go through a whole deploy to verify.